### PR TITLE
Update teams and governance content

### DIFF
--- a/content/community/teams.md
+++ b/content/community/teams.md
@@ -18,9 +18,9 @@ Helping uphold the code of conduct
 
 #### Members
 
-* Natali Vlatko
 * Dan Rowe
 * Jordan Chernev
+* Natali Vlatko
 
 ### Core (core)
 
@@ -76,4 +76,3 @@ API's and endpoints
 * Darach Ennis
 * Heinz Gies
 * Matthias Wahl
-

--- a/content/governance/_index.md
+++ b/content/governance/_index.md
@@ -4,9 +4,9 @@ title = "Governance"
 description = "Tremor project governance model"
 +++
 
-The tremor project originated as an internal solution at Wayfair and is currently transitioning
-to fully open community based open source development. There are three pillars to the governance
-model for tremor that are worth explicitly acknowledging.
+The tremor project originated as an internal solution at Wayfair and has become a CNCF sandbox
+project with an open community based open source development model. There are three pillars to the
+governance model for tremor that are worth explicitly acknowledging.
 
 ## Governance model
 


### PR DESCRIPTION
Update the teams list and update governance page to reflect tremor being a CNCF sandbox project